### PR TITLE
Customer service softdelete

### DIFF
--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -2,20 +2,11 @@ package com.asaas.mini
 
 import javax.transaction.Transactional
 
-@Transactional // faz com que o método aconteça por completo, ou de rollback
+@Transactional
 class CustomerService {
 
-    //cadastro de customer
-
-    //Atualização de customer
-
-    //Listagem e filtros de customer
-
-    //Busca por ID
-
-    //Soft delete
     public void deleteCustomer(Long id) {
-        Customer customer = customer.findByIdAndDeleted(id, false); // procura no banco pelo ID e nao deletado
+        Customer customer = customer.findByIdAndDeleted(id, false)
 
         if (!customer) {
             throw new IllegalArgumentException("Customer not found")
@@ -30,11 +21,4 @@ class CustomerService {
             throw new IllegalArgumentException("Customer has active payments")
         }
     }
-
-    //restore
 }
-
-/* Service:
-    Camada responsável pelas regras de negócio e as operações específicas do domínio;
-
- */

--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -13,7 +13,9 @@ class CustomerService {
         }
 
         validateDelete(customer)
-        customer.softDelete()
+        customer.deleted = true
+        customer.markDirty('deleted')
+        customer.save(flush:true, failOnError:true)
     }
 
     private validateDelete(Customer customer) {

--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -1,0 +1,40 @@
+package com.asaas.mini
+
+import javax.transaction.Transactional
+
+@Transactional // faz com que o método aconteça por completo, ou de rollback
+class CustomerService {
+
+    //cadastro de customer
+
+    //Atualização de customer
+
+    //Listagem e filtros de customer
+
+    //Busca por ID
+
+    //Soft delete
+    public void deleteCustomer(Long id) {
+        Customer customer = customer.findByIdAndDeleted(id, false); // procura no banco pelo ID e nao deletado
+
+        if (!customer) {
+            throw new IllegalArgumentException("Customer not found")
+        }
+
+        validateDelete(customer)
+        customer.softDelete()
+    }
+
+    private validateDelete(Customer customer) {
+        if (Payment.findByCustomerAndDeleted(customer, false)) {
+            throw new IllegalArgumentException("Customer has active payments")
+        }
+    }
+
+    //restore
+}
+
+/* Service:
+    Camada responsável pelas regras de negócio e as operações específicas do domínio;
+
+ */

--- a/src/main/groovy/com/asaas/mini/utils/BaseEntity.groovy
+++ b/src/main/groovy/com/asaas/mini/utils/BaseEntity.groovy
@@ -1,42 +1,13 @@
 package com.asaas.mini.utils
 
 class BaseEntity {
-    Date dateCreated;
-    Date lastUpdate;
-    Boolean deleted = false;
+    Date dateCreated
+
+    Date lastUpdate
+
+    Boolean deleted = false
 
     static mapping = {
         tablePerHierarchy false
     }
-
-    void softDelete() {
-        this.deleted = true;
-    }
-
-    void restore() {
-        this.deleted = false;
-    }
-
 }
-
-/*
-MAPPING
-
-    1. o nome mapping é predefinido pelo GORM. O Grails (via GORM) procura um campo mapping dentro das classes de
-domínio para entender como mapear a classe no banco de dados.
-
-    2. O Grails só reconhece *static mapping* como bloco de configuração do mapeamento ORM
-
-
-TABLE PER HIERARCHY - TPH
-
-    1. Quando é usado herança, o hibernate decide como irá criar tabelas no banco de dados;
-
-    2. Table per hierarchy (TPH) é ativado por padrão, com ele, todas as entidades filhas da BaseEntity ficam na mesma
-tabela, sendo diferenciadas por uma coluna Class, que diferencia os tipos;
-
-    3. Ao definir o TPH como falso, é definido que é desejado uma tabela para cada entidade;
-
-    4. Com a desativação do TPH é ativado o TPS = cada entidade filha tem sua própria tabela no banco. É incluido
-automaticamente em cada tabela as colunass herdadas de BaseEntity.
-*/


### PR DESCRIPTION
### Impacto
Criação do método deleteCustomer, possibilitando a marcação do Customer como deleted.
### Release Note (Descrição que irá no forno)
Criado o método deleteCustomer em CustomerService, permitindo a marcação de Customers como deleted, desde que:
- O cliente exista;
- O cliente esteja ativo;
- O cliente não possua pagamentos ativos.
### PR Predecessora
[Criação do domain customer #3
](https://github.com/bruna-giovanella/mini-asaas/pull/3)
### Link da tarefa no JIRA
[Delete customer - CustomerService
](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-37)
### Cenários testados
Aguardado a criação do Controller para observar comportamento do banco.