### PR TITLE
Customer service restore

### DIFF
--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -2,20 +2,11 @@ package com.asaas.mini
 
 import javax.transaction.Transactional
 
-@Transactional // faz com que o método aconteça por completo, ou de rollback
+@Transactional
 class CustomerService {
 
-    //cadastro de customer
-
-    //Atualização de customer
-
-    //Listagem e filtros de customer
-
-    //Busca por ID
-
-    //Soft delete
     public void deleteCustomer(Long id) {
-        Customer customer = customer.findByIdAndDeleted(id, false); // procura no banco pelo ID e nao deletado
+        Customer customer = customer.findByIdAndDeleted(id, false)
 
         if (!customer) {
             throw new IllegalArgumentException("Customer not found")
@@ -31,7 +22,6 @@ class CustomerService {
         }
     }
 
-    //restore
     public void restoreCustomer(Long id) {
         Customer customer = customer.findByIdAndDeleted(id, true)
 
@@ -42,7 +32,3 @@ class CustomerService {
         customer.restore()
     }
 }
-
-/* Service:
-    Camada responsável pelas regras de negócio e as operações específicas do domínio;
- */

--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -15,7 +15,7 @@ class CustomerService {
         validateDelete(customer)
         customer.deleted = true
         customer.markDirty('deleted')
-        customer.save(flush:true, failOnError:true)
+        customer.save(failOnError:true)
     }
 
     private validateDelete(Customer customer) {
@@ -33,6 +33,6 @@ class CustomerService {
 
         customer.deleted = false
         customer.markDirty('deleted')
-        customer.save(flush: true, failOnError: true)
+        customer.save(failOnError: true)
     }
 }

--- a/grails-app/services/com/asaas/mini/CustomerService.groovy
+++ b/grails-app/services/com/asaas/mini/CustomerService.groovy
@@ -32,9 +32,17 @@ class CustomerService {
     }
 
     //restore
+    public void restoreCustomer(Long id) {
+        Customer customer = customer.findByIdAndDeleted(id, true)
+
+        if (!customer) {
+            throw new IllegalArgumentException("Customer not found or is not deleted")
+        }
+
+        customer.restore()
+    }
 }
 
 /* Service:
     Camada responsável pelas regras de negócio e as operações específicas do domínio;
-
  */


### PR DESCRIPTION
### Impacto
Criação do método restoreCustomer, possibilitando a marcação do Customer como não deletado.
### Release Note (Descrição que irá no forno)
Criado o método deleteCustomer em CustomerService, permitindo a marcação de Customers como deleted, desde que:
- O cliente exista;
- O cliente esteja deletado;
### PR Predecessora
[Customer service softdelete #5
](https://github.com/bruna-giovanella/mini-asaas/pull/5)
### Link da tarefa no JIRA
[Restore Customer - CustomerService
](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-53)
### Cenários testados
Aguardado a criação do Controller para observar comportamento do banco.