### PR TITLE
Customer controller restore

### DIFF
--- a/grails-app/controllers/com/asaas/mini/CustomerController.groovy
+++ b/grails-app/controllers/com/asaas/mini/CustomerController.groovy
@@ -12,9 +12,9 @@ class CustomerController {
             Customer customer = customerService.save(params)
             respond customer, [status: 201]
         } catch (ValidationException e) {
-            render(status: 400, contentType: 'application/json', text: [errors: e.errors.allErrors*.defaultMessage].toString())
+            render(status: 400, contentType: 'application/json', text: [errors: "Um erro inesperado aconteceu"].toString())
         } catch (Exception ignored) {
-            render(status: 500, contentType: 'application/json', text: [error: "Internal server error"].toString())
+            render(status: 500, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
         }
     }
 
@@ -24,11 +24,11 @@ class CustomerController {
             customerService.deleteCustomer(id)
             render(status: 204)
         } catch (IllegalArgumentException e) {
-            render(status: 404, contentType: 'application/json', text: [error: e.message].toString())
+            render(status: 404, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
         } catch (ValidationException e) {
-            render(status: 400, contentType: 'application/json', text: [errors: e.errors.allErrors*.defaultMessage].toString())
+            render(status: 400, contentType: 'application/json', text: [errors: "um erro inesperado aconteceu"].toString())
         } catch (Exception ignored) {
-        render(status: 500, contentType: 'application/json', text: [error: "Internal server error"].toString())
+        render(status: 500, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
     }
     }
 
@@ -38,11 +38,11 @@ class CustomerController {
             customerService.restoreCustomer(id)
             render(status: 200)
         } catch (IllegalArgumentException e) {
-            render(status: 404, contentType: 'application/json', text: [error: e.message].toString())
+            render(status: 404, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
         } catch (ValidationException e) {
-            render(status: 400, contentType: 'application/json', text: [errors: e.errors.allErrors*.defaultMessage].toString())
+            render(status: 400, contentType: 'application/json', text: [errors: "Um erro inesperado aconteceu"].toString())
         } catch (Exception ignored) {
-            render(status: 500, contentType: 'application/json', text: [error: "Internal server error"].toString())
+            render(status: 500, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
         }
     }
 }

--- a/grails-app/controllers/com/asaas/mini/CustomerController.groovy
+++ b/grails-app/controllers/com/asaas/mini/CustomerController.groovy
@@ -2,6 +2,8 @@ package com.asaas.mini
 
 import org.grails.datastore.mapping.validation.ValidationException
 
+import java.util.function.LongConsumer
+
 class CustomerController {
 
     static responseFormats = ['json']
@@ -21,6 +23,20 @@ class CustomerController {
             Long id = params.id as Long
             customerService.deleteCustomer(id)
             render(status: 204)
+        } catch (IllegalArgumentException e) {
+            render(status: 404, contentType: 'application/json', text: [error: e.message].toString())
+        } catch (ValidationException e) {
+            render(status: 400, contentType: 'application/json', text: [errors: e.errors.allErrors*.defaultMessage].toString())
+        }
+    }
+
+    def restore() {
+        try {
+            Long id = params.id as Long
+            customerService.restoreCustomer(id)
+            render(status: 200)
+        } catch (IllegalArgumentException e) {
+            render(status: 404, contentType: 'application/json', text: [error: e.message].toString())
         } catch (ValidationException e) {
             render(status: 400, contentType: 'application/json', text: [errors: e.errors.allErrors*.defaultMessage].toString())
         }

--- a/grails-app/controllers/com/asaas/mini/CustomerController.groovy
+++ b/grails-app/controllers/com/asaas/mini/CustomerController.groovy
@@ -2,8 +2,6 @@ package com.asaas.mini
 
 import org.grails.datastore.mapping.validation.ValidationException
 
-import java.util.function.LongConsumer
-
 class CustomerController {
 
     static responseFormats = ['json']

--- a/src/main/groovy/com/asaas/mini/utils/BaseEntity.groovy
+++ b/src/main/groovy/com/asaas/mini/utils/BaseEntity.groovy
@@ -18,6 +18,7 @@ class BaseEntity {
 
     void restore() {
         this.deleted = false
+        this.markDirty('deleted')
         this.save(flush: true, failOnError: true)
     }
 


### PR DESCRIPTION
### Impacto
Criação do caminho `restore` em `CustomerController,` para poder realizar a ação de restaurar um cliente deletado, implementado em `CustomerService` e `BaseEntity.`
### Release Note (Descrição que irá no forno)
Criado o caminho `restore` em `CustomerController,` permitindo, efetivamente, a marcação do Customer como ativo ao informar o ID desejado.
### PR Predecessora
Customer controller softdelete #10
### Link da tarefa no JIRA
[Restore Customer - Customer Controller
](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-56)
### Observabilidade
Houve problemas na atualização do banco. Por mais que o código estivesse, efetivamente, realizando o restore do customer, o banco não estava recebendo a atualização pelo GORM. 
A solução encontrada para contornar o problema foi a adição de `this.markDirty('deleted')` ao método `restore` em `BaseEntity`
### Cenários testados
- Realizado teste em Postman: `PUT` http://localhost:8080/customer/restore?id=1
- Observado a mudança da informação armazenada em banco de dados