### PR TITLE
Payment service controller ConfirmInCash

### DIFF
--- a/grails-app/controllers/com/asaas/mini/PaymentController.groovy
+++ b/grails-app/controllers/com/asaas/mini/PaymentController.groovy
@@ -104,6 +104,18 @@ class PaymentController {
         }
     }
 
+    def confirmInCash() {
+        try {
+            Customer customer = getCustomerLogged()
+            Long id = params.long('id')
+
+            Payment payment = paymentService.confirmInCash(id, customer)
+            respond payment, [status: 200]
+        } catch (IllegalArgumentException | SecurityException | IllegalStateException e) {
+            render status: 400, text: e.message
+        }
+    }
+
     private Customer getCustomerLogged() {
         return Customer.get(1L)
     }

--- a/grails-app/services/com/asaas/mini/PaymentService.groovy
+++ b/grails-app/services/com/asaas/mini/PaymentService.groovy
@@ -188,4 +188,29 @@ class PaymentService {
         payment.deleted = false
         payment.save(failOnError: true)
     }
+
+    public Payment confirmInCash(Long id, Customer customer) {
+        if (!id) {
+            throw new IllegalArgumentException("Payment ID is required")
+        }
+
+        Payment payment = Payment.findById(id)
+        if (!payment || payment.status == PaymentStatus.EXCLUIDA) {
+            throw new IllegalArgumentException("Payment not found")
+        }
+
+        if (payment.payer.customer.id != customer.id) {
+            throw new SecurityException("Access denied: Payment does not belong to the logged customer")
+        }
+
+        if (payment.status != PaymentStatus.AGUARDANDO_PAGAMENTO) {
+            throw new IllegalStateException("Only payments with status 'Aguardando Pagamento' can be confirmed in cash")
+        }
+
+        payment.status = PaymentStatus.RECEBIDA
+        payment.confirmedInCash = true
+        payment.save(flush: true)
+
+        return payment
+    }
 }


### PR DESCRIPTION
### Impacto
Criação do método `confirmInCash` em `PaymentService` e implementação do caminho `confirmInCash` em `PaymentController` para atualizar manualmente o status de um Payment como RECEBIDO.
### Release Note (Descrição que irá no forno)
Criado o método `confirmInCash`, permitindo a atualização manual do status de um Payment para RECEBIDO, em casos onde o recebimento se dá por dinheiro físico. Implementado o caminho `confirmInCash`, onde o payment é atualizado. 
A atualização do status é permitida se:
- For fornecido o ID do payment;
- O payment em questão for pertencente ao payer logado;
- O payment for encontrado e não estiver EXCLUIDO;
- O payment estiver com status AGUARDANDO_PAGAMENTO
### PR Predecessora
Integridade sofdelete #31
### Link da tarefa no JIRA
- [Confirmação de Pagamento em Dinheiro](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-22)
- ### Cenários testados
- Realizado teste em Postman: `POST` http://localhost:8080/payment/confirmInCash?id=1
- Observado alterações em banco de dados