### PR TITLE
User service controller restore

### DIFF
--- a/grails-app/controllers/com/asaas/mini/auth/UserController.groovy
+++ b/grails-app/controllers/com/asaas/mini/auth/UserController.groovy
@@ -57,7 +57,7 @@ class UserController {
         }
     }
 
-    @Secured('permitAll')
+    @Secured(['ROLE_ADMINISTRADOR'])
     def restore() {
         try {
             Customer customer = getCustomerLogged()

--- a/grails-app/controllers/com/asaas/mini/auth/UserController.groovy
+++ b/grails-app/controllers/com/asaas/mini/auth/UserController.groovy
@@ -57,7 +57,25 @@ class UserController {
         }
     }
 
+    @Secured('permitAll')
+    def restore() {
+        try {
+            Customer customer = getCustomerLogged()
+            Long id = params.long("id")
+            userService.restore(customer, id)
+            render(status: 204)
+
+        } catch (IllegalArgumentException illegalArgumentException) {
+            render(status: 404, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
+        } catch (ValidationException validationException) {
+            render(status: 400, contentType: 'application/json', text: [errors: "Um erro inesperado aconteceu"].toString())
+        } catch (Exception exception) {
+            log.error("Erro ao deletar usuário", exception)
+            render(status: 500, contentType: 'application/json', text: [error: "Um erro inesperado aconteceu"].toString())
+        }
+    }
+
     private Customer getCustomerLogged() {
-        return Customer.get(3L)
+        return Customer.get(1L)
     }
 }

--- a/grails-app/services/com/asaas/mini/auth/UserService.groovy
+++ b/grails-app/services/com/asaas/mini/auth/UserService.groovy
@@ -56,4 +56,27 @@ class UserService {
 
     }
 
+    public void restore(Customer customer, Long id) {
+        if (!id) {
+            throw new IllegalArgumentException("O ID é obrigatório")
+        }
+
+        User user = User.findByIdAndCustomerAndDeleted(id, customer, true)
+        if (!user) {
+            throw new IllegalArgumentException("Usuário não encontrado")
+        }
+        UserRole userRole = UserRole.findByUserAndDeleted(user, true)
+
+
+        user.deleted = false
+        user.markDirty('deleted')
+        user.save(failOnError:true)
+
+        userRole.deleted = false
+        userRole.markDirty('deleted')
+        userRole.save(failOnError:true)
+
+    }
+
+
 }


### PR DESCRIPTION
### Impacto
Implementado restore em `user` criado, com consequente marcação de ativo em `user_role.`
### Release Note 
Implementado restore em `user,` com efeito cascata para o `user_role`
### PR Predecessora
User service controller delete #45
### Link da tarefa no JIRA
- [Restore User - UserService](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-87)
- [Restore User - UserController](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-88)
### Cenários testados
- Realizado testes em Postman 
- Observado persistência em banco