### PR TITLE
Atlas edit payer

### DIFF
--- a/grails-app/views/payer/edit.gsp
+++ b/grails-app/views/payer/edit.gsp
@@ -85,7 +85,7 @@
 
                 <atlas-button
                     description="Voltar"
-                    href="${createLink(controller: 'payer', action: 'show', id: payer?.id)}">
+                    href="${createLink(controller: 'payer', action: 'index', id: payer?.id)}">
                     Voltar
                 </atlas-button>
             </atlas-layout>

--- a/grails-app/views/payer/edit.gsp
+++ b/grails-app/views/payer/edit.gsp
@@ -1,62 +1,113 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Editar Pagador</title>
-</head>
-<body>
-<h1>Editar Pagador</h1>
+<g:applyLayout name="main">
 
-<g:if test="${flash.message}">
-    <p>${flash.message}</p>
-</g:if>
+    <atlas-page-header page-name="Editar Cliente"></atlas-page-header>
 
-<g:form controller="payer" action="update">
-    <g:hiddenField name="id" value="${payer?.id}"/>
+    <g:if test="${flash.message}">
+        <div class="floating-alert">
+            <atlas-alert type="${flash.message?.contains('erro') || flash.message?.contains('Erro') || flash.message?.contains('não é possível') ? 'danger' : 'success'}">
+                ${flash.message}
+            </atlas-alert>
+        </div>
+    </g:if>
 
-    <label>Nome:</label>
-    <g:textField name="name" value="${payer?.name}"/><br/>
+    <atlas-panel>
+        <atlas-text size="md" bold>Informações Pessoais</atlas-text>
 
-    <label>Email:</label>
-    <g:textField name="email" value="${payer?.email}"/><br/>
+        <g:form controller="payer" action="update" method="post">
+            <g:hiddenField name="id" value="${payer?.id}"/>
 
-    <label>Telefone:</label>
-    <g:textField name="contactNumber" value="${payer?.contactNumber}"/><br/>
+            <atlas-grid>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Nome *</atlas-text>
+                        <g:textField name="name" value="${payer?.name}" class="form-control" placeholder="Digite o nome completo" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-    <label>CPF/CNPJ:</label>
-    <g:textField name="cpfCnpj" value="${payer?.cpfCnpj}"/><br/>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Email *</atlas-text>
+                        <g:textField name="email" value="${payer?.email}" class="form-control" placeholder="exemplo@email.com" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-    <h3>Endereço</h3>
-    <label>CEP:</label>
-    <g:textField name="cep" value="${payer?.address?.cep}"/><br/>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Telefone *</atlas-text>
+                        <g:textField name="contactNumber" value="${payer?.contactNumber}" class="form-control" placeholder="(00) 00000-0000" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-    <label>Cidade:</label>
-    <g:textField name="city" value="${payer?.address?.city}"/><br/>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>CPF/CNPJ *</atlas-text>
+                        <g:textField name="cpfCnpj" value="${payer?.cpfCnpj}" class="form-control" placeholder="000.000.000-00 ou 00.000.000/0000-00" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-    <label>Estado:</label>
-    <g:textField name="state" value="${payer?.address?.state}"/><br/>
+                <atlas-divider></atlas-divider>
 
-    <label>Complemento:</label>
-    <g:textField name="complement" value="${payer?.address?.complement}"/><br/>
+                <atlas-text size="md" bold>Endereço</atlas-text>
 
-    <g:submitButton name="update" value="Salvar"/>
-</g:form>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>CEP *</atlas-text>
+                        <g:textField name="cep" value="${payer?.address?.cep}" class="form-control" placeholder="00000-000" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-<hr/>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Cidade *</atlas-text>
+                        <g:textField name="city" value="${payer?.address?.city}" class="form-control" placeholder="Digite a cidade" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-<g:if test="${!payer.deleted}">
-    <g:form controller="payer" action="delete" method="post">
-        <g:hiddenField name="id" value="${payer?.id}"/>
-        <g:submitButton name="delete" class="btn btn-danger" value="Deletar"/>
-    </g:form>
-</g:if>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Estado *</atlas-text>
+                        <g:textField name="state" value="${payer?.address?.state}" class="form-control" placeholder="Digite o estado" required="true"/>
+                    </atlas-col>
+                </atlas-row>
 
-<g:if test="${payer.deleted}">
-    <g:form controller="payer" action="restore" method="post">
-        <g:hiddenField name="id" value="${payer?.id}"/>
-        <g:submitButton name="restore" class="btn btn-danger" value="Restaurar"/>
-    </g:form>
-</g:if>
+                <atlas-row>
+                    <atlas-col>
+                        <atlas-text size="sm" bold>Complemento</atlas-text>
+                        <g:textField name="complement" value="${payer?.address?.complement}" class="form-control" placeholder="Apartamento, casa, etc."/>
+                    </atlas-col>
+                </atlas-row>
+            </atlas-grid>
 
-<p><g:link action="show" id="${payer?.id}">Voltar</g:link></p>
-</body>
-</html>
+            <atlas-divider></atlas-divider>
+
+            <atlas-layout gap="2" inline>
+                <g:submitButton name="update" value="Salvar Alterações" class="btn btn-primary"/>
+
+                <atlas-button
+                    description="Voltar"
+                    href="${createLink(controller: 'payer', action: 'show', id: payer?.id)}">
+                    Voltar
+                </atlas-button>
+            </atlas-layout>
+
+        </g:form>
+
+    </atlas-panel>
+</g:applyLayout>
+
+<style>
+.form-control {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+    margin-bottom: 8px;
+}
+
+.form-control:focus {
+    border-color: #007bff;
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+</style>


### PR DESCRIPTION
### Impacto
Realizada estilização das telas com Atlas
### Release Note
Realizada estilização da tela payer/edit.gsp com atlas e layout main.
### PR Predecessora
Atlas edit customer #67
### Link da tarefa no JIRA
[atlas - edit payer
](https://brugiovanella.atlassian.net/jira/software/projects/MIN/boards/3?selectedIssue=MIN-103)
### Prints do desenvolvimento
<img width="1920" height="998" alt="image" src="https://github.com/user-attachments/assets/35cc6557-00d9-4323-b7ac-6fd4aa7da5d1" />
<img width="1920" height="998" alt="image" src="https://github.com/user-attachments/assets/3649699e-83bc-4424-96fe-30311e47dc18" />

### Observabilidade
O atlas-form não realizou o submit dos dados cadastrados. Foi realizado tentativa de criação de script JS e iniciado conversa com o Gean Farias para observar se havia discrepância no código usado e o padrão de uso. Porém, mesmo com as alterações sugeridas, o envio do form não foi efetivo. 
Foi utilizado g:form e estilização manual como alternativa ao problema.
### Cenários testados
Realizada tentativa de cadastro via browser.

